### PR TITLE
speed up SlackLogInitialization

### DIFF
--- a/src/Lykke.Logs/Lykke.Logs.csproj
+++ b/src/Lykke.Logs/Lykke.Logs.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="AsyncFriendlyStackTrace" Version="1.6.0" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="Lykke.AzureQueueIntegration" Version="2.2.0" />
+    <PackageReference Include="Lykke.AzureQueueIntegration" Version="2.3.0" />
     <PackageReference Include="Lykke.AzureStorage" Version="8.6.0" />
     <PackageReference Include="Lykke.Common" Version="7.0.1" />
     <PackageReference Include="Lykke.SlackNotification.AzureQueue" Version="2.0.5" />


### PR DESCRIPTION
in scope of https://lykkex.atlassian.net/browse/LWDEV-8994?src=confmacro
1) Init log senders for each log level in parallel instead of consistently
2) Use "fire n forget" parameter, introduced in https://github.com/LykkeCity/AzureQueueIntegration/pull/6